### PR TITLE
feat: add media harness and gif optimization toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "deploy:commands": "tsx scripts/deploy-commands.ts",
     "clear:commands": "tsx scripts/clear-commands.ts",
     "migrate:from-old": "tsx scripts/migrate-from-old-db.ts",
+    "media:harness": "tsx scripts/media-harness.ts",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
     "prepare": "husky install",

--- a/scripts/media-harness.ts
+++ b/scripts/media-harness.ts
@@ -1,0 +1,374 @@
+#!/usr/bin/env tsx
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { analyzeGif, optimizeGif } from '@/shared/media/gifToolkit';
+import { FfmpegNotFoundError, exportVideo } from '@/shared/media/videoToolkit';
+
+interface HarnessOptions {
+  input: string;
+  outDir: string;
+  fps: number;
+  bitrate: number;
+  keyint: number;
+}
+
+interface HarnessSummary {
+  baseline: {
+    frameCount: number;
+    fps: number;
+    jitter: number;
+    paletteEstimate: number;
+    delaysMs: number[];
+  };
+  optimized: {
+    frameCount: number;
+    fps: number;
+    jitter: number;
+    paletteEstimate: number;
+    removedDuplicates: number;
+  };
+  files: {
+    optimizedGif: number;
+    mp4: number | null;
+    webm: number | null;
+    apng: number | null;
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  await fs.mkdir(options.outDir, { recursive: true });
+
+  const baseline = await analyzeGif(options.input);
+  const baselineCopy = path.join(options.outDir, path.basename(options.input));
+  await fs.copyFile(options.input, baselineCopy);
+
+  const optimized = await optimizeGif(options.input, path.join(options.outDir, 'optimized.gif'), {
+    targetFps: options.fps,
+  });
+
+  const mp4Path = await tryExport({
+    input: optimized.outputPath,
+    outputPath: path.join(options.outDir, 'loop.mp4'),
+    container: 'mp4',
+    fps: options.fps,
+    bitrateKbps: options.bitrate,
+    keyframeInterval: options.keyint,
+  });
+
+  const webmPath = await tryExport({
+    input: optimized.outputPath,
+    outputPath: path.join(options.outDir, 'loop.webm'),
+    container: 'webm',
+    fps: options.fps,
+    bitrateKbps: options.bitrate,
+    keyframeInterval: options.keyint,
+  });
+
+  const apngPath = await tryExport({
+    input: optimized.outputPath,
+    outputPath: path.join(options.outDir, 'loop.apng'),
+    container: 'apng',
+    fps: options.fps,
+  });
+
+  const summary: HarnessSummary = {
+    baseline: {
+      frameCount: baseline.frameCount,
+      fps: baseline.timing.fps,
+      jitter: baseline.timing.stdDeviationMs,
+      paletteEstimate: baseline.paletteEstimate,
+      delaysMs: baseline.delaysMs.slice(0, 8),
+    },
+    optimized: {
+      frameCount: optimized.analysisAfter.frameCount,
+      fps: optimized.analysisAfter.timing.fps,
+      jitter: optimized.analysisAfter.timing.stdDeviationMs,
+      paletteEstimate: optimized.analysisAfter.paletteEstimate,
+      removedDuplicates: optimized.removedDuplicateFrames,
+    },
+    files: {
+      optimizedGif: await fileSize(optimized.outputPath),
+      mp4: mp4Path ? await fileSize(mp4Path) : null,
+      webm: webmPath ? await fileSize(webmPath) : null,
+      apng: apngPath ? await fileSize(apngPath) : null,
+    },
+  };
+
+  console.log('Baseline delay (ms):', baseline.delaysMs.slice(0, 10));
+  console.log('Baseline fps/jitter:', baseline.timing.fps, baseline.timing.stdDeviationMs);
+  console.log('Optimized fps/jitter:', optimized.analysisAfter.timing.fps, optimized.analysisAfter.timing.stdDeviationMs);
+  console.log('File sizes:', {
+    optimizedGif: formatBytes(summary.files.optimizedGif),
+    mp4: summary.files.mp4 ? formatBytes(summary.files.mp4) : 'n/a',
+    webm: summary.files.webm ? formatBytes(summary.files.webm) : 'n/a',
+    apng: summary.files.apng ? formatBytes(summary.files.apng) : 'n/a',
+  });
+
+  const html = renderHtml({
+    inputName: path.basename(options.input),
+    summary,
+    assets: {
+      baselineGif: path.basename(baselineCopy),
+      optimizedGif: path.basename(optimized.outputPath),
+      mp4: mp4Path ? path.basename(mp4Path) : null,
+      webm: webmPath ? path.basename(webmPath) : null,
+      apng: apngPath ? path.basename(apngPath) : null,
+    },
+  });
+
+  const reportPath = path.join(options.outDir, 'report.html');
+  await fs.writeFile(reportPath, html, 'utf8');
+  console.log(`Report saved to ${reportPath}`);
+}
+
+async function tryExport(request: Parameters<typeof exportVideo>[0]): Promise<string | null> {
+  try {
+    return await exportVideo(request);
+  } catch (error) {
+    if (error instanceof FfmpegNotFoundError) {
+      console.warn('FFmpeg not available, skipping export for', request.container);
+      return null;
+    }
+
+    console.warn('Export failed:', error);
+    return null;
+  }
+}
+
+function parseArgs(argv: string[]): HarnessOptions {
+  const options: HarnessOptions = {
+    input: '',
+    outDir: path.resolve('simulation/media-report'),
+    fps: 30,
+    bitrate: 2200,
+    keyint: 60,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--input' && argv[i + 1]) {
+      options.input = path.resolve(argv[++i]);
+    } else if (arg === '--outDir' && argv[i + 1]) {
+      options.outDir = path.resolve(argv[++i]);
+    } else if (arg === '--fps' && argv[i + 1]) {
+      options.fps = Number(argv[++i]);
+    } else if (arg === '--bitrate' && argv[i + 1]) {
+      options.bitrate = Number(argv[++i]);
+    } else if (arg === '--keyint' && argv[i + 1]) {
+      options.keyint = Number(argv[++i]);
+    }
+  }
+
+  if (!options.input) {
+    throw new Error('Missing required --input path');
+  }
+
+  return options;
+}
+
+async function fileSize(filePath: string): Promise<number> {
+  const stats = await fs.stat(filePath);
+  return stats.size;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  const k = 1024;
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const value = bytes / k ** i;
+  return `${value.toFixed(2)} ${units[i]}`;
+}
+
+function renderHtml({
+  inputName,
+  summary,
+  assets,
+}: {
+  inputName: string;
+  summary: HarnessSummary;
+  assets: {
+    baselineGif: string;
+    optimizedGif: string;
+    mp4: string | null;
+    webm: string | null;
+    apng: string | null;
+  };
+}): string {
+  const cards: string[] = [];
+
+  cards.push(
+    renderCard(
+      'Original GIF',
+      assets.baselineGif,
+      summary.baseline.fps,
+      summary.baseline.jitter,
+      `<img src="${assets.baselineGif}" alt="Original GIF" />`,
+    ),
+  );
+
+  cards.push(
+    renderCard(
+      'Optimized GIF',
+      assets.optimizedGif,
+      summary.optimized.fps,
+      summary.optimized.jitter,
+      `<img src="${assets.optimizedGif}" alt="Optimized GIF" />`,
+    ),
+  );
+
+  if (assets.mp4) {
+    cards.push(
+      renderCard(
+        'MP4 (H.264)',
+        assets.mp4,
+        summary.optimized.fps,
+        summary.optimized.jitter,
+        `<video src="${assets.mp4}" autoplay loop muted playsinline></video>`,
+      ),
+    );
+  }
+
+  if (assets.webm) {
+    cards.push(
+      renderCard(
+        'WebM (VP9)',
+        assets.webm,
+        summary.optimized.fps,
+        summary.optimized.jitter,
+        `<video src="${assets.webm}" autoplay loop muted playsinline></video>`,
+      ),
+    );
+  }
+
+  if (assets.apng) {
+    cards.push(
+      renderCard(
+        'APNG',
+        assets.apng,
+        summary.optimized.fps,
+        summary.optimized.jitter,
+        `<img src="${assets.apng}" alt="APNG" />`,
+      ),
+    );
+  }
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Media Harness Report</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+        margin: 0;
+        padding: 2rem;
+      }
+      h1 {
+        margin-top: 0;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 1.5rem;
+      }
+      .card {
+        background: rgba(30, 41, 59, 0.8);
+        border-radius: 12px;
+        padding: 1rem;
+        backdrop-filter: blur(8px);
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+      }
+      .card header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 0.75rem;
+      }
+      .media-shell {
+        display: grid;
+        place-items: center;
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 8px;
+        overflow: hidden;
+        height: 260px;
+        margin-bottom: 0.75rem;
+      }
+      img,
+      video {
+        max-width: 100%;
+        max-height: 100%;
+        display: block;
+      }
+      .stats {
+        display: flex;
+        gap: 1rem;
+      }
+      .stats span {
+        display: inline-flex;
+        flex-direction: column;
+        font-size: 0.9rem;
+        color: #94a3b8;
+      }
+      .stats strong {
+        color: #f8fafc;
+        font-size: 1.25rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Media Harness</h1>
+    <p>Baseline vs optimized outputs for <strong>${inputName}</strong>.</p>
+    <section class="grid">
+      ${cards.join('\n      ')}
+    </section>
+    <script>
+      const counters = document.querySelectorAll('[data-expected-fps]');
+      counters.forEach((counter) => {
+        const target = Number(counter.getAttribute('data-expected-fps'));
+        const jitter = Number(counter.getAttribute('data-jitter'));
+        function update() {
+          counter.querySelector('.fps').textContent = target.toFixed(2) + ' fps';
+          counter.querySelector('.jitter').textContent = jitter.toFixed(2) + ' ms jitter';
+        }
+        update();
+        setInterval(update, 1000);
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+function renderCard(
+  title: string,
+  source: string,
+  fps: number,
+  jitter: number,
+  markup?: string,
+): string {
+  const media = markup ?? `<img src="${source}" alt="${title}" />`;
+  return `<article class="card" data-expected-fps="${fps}" data-jitter="${jitter}">
+    <header>
+      <h2>${title}</h2>
+      <span>${source}</span>
+    </header>
+    <div class="media-shell">${media}</div>
+    <div class="stats">
+      <span><strong class="fps">${fps.toFixed(2)} fps</strong><small>Playback</small></span>
+      <span><strong class="jitter">${jitter.toFixed(2)} ms</strong><small>Jitter</small></span>
+    </div>
+  </article>`;
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/shared/media/frameTiming.ts
+++ b/src/shared/media/frameTiming.ts
@@ -1,0 +1,55 @@
+import { roundTo } from './rounding';
+
+export interface FrameTimingStats {
+  averageDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  stdDeviationMs: number;
+  fps: number;
+}
+
+export function calculateFrameTimingStats(delaysMs: number[]): FrameTimingStats {
+  if (delaysMs.length === 0) {
+    return {
+      averageDelayMs: 0,
+      minDelayMs: 0,
+      maxDelayMs: 0,
+      stdDeviationMs: 0,
+      fps: 0,
+    };
+  }
+
+  const total = delaysMs.reduce((sum, delay) => sum + delay, 0);
+  const average = total / delaysMs.length;
+  const min = Math.min(...delaysMs);
+  const max = Math.max(...delaysMs);
+  const variance =
+    delaysMs.reduce((acc, delay) => acc + (delay - average) ** 2, 0) / delaysMs.length;
+  const stdDeviation = Math.sqrt(variance);
+  const fps = average > 0 ? 1000 / average : 0;
+
+  return {
+    averageDelayMs: roundTo(average, 3),
+    minDelayMs: roundTo(min, 3),
+    maxDelayMs: roundTo(max, 3),
+    stdDeviationMs: roundTo(stdDeviation, 3),
+    fps: roundTo(fps, 3),
+  };
+}
+
+export function inferDelaysFromDuration(durationMs: number, frameCount: number): number[] {
+  if (frameCount <= 0) {
+    return [];
+  }
+
+  const delay = durationMs / frameCount;
+  return Array.from({ length: frameCount }, () => roundTo(delay, 3));
+}
+
+export function roundDelays(delays: number[], precision = 3): number[] {
+  return delays.map((value) => roundTo(value, precision));
+}
+
+export function ensureConstantDelay(delays: number[], desiredDelay: number): number[] {
+  return delays.map(() => roundTo(desiredDelay, 3));
+}

--- a/src/shared/media/gifToolkit.ts
+++ b/src/shared/media/gifToolkit.ts
@@ -1,0 +1,318 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { createCanvas, ImageData } from '@napi-rs/canvas';
+import GIFEncoder from 'gifencoder';
+import { decompressFrames, parseGIF, ParsedFrame } from 'gifuct-js';
+
+import { calculateFrameTimingStats, FrameTimingStats } from './frameTiming';
+import { roundTo } from './rounding';
+
+const HUNDREDTHS_TO_MS = 10;
+
+export interface GifFrame {
+  data: Uint8ClampedArray;
+  delayMs: number;
+  disposalType: number;
+}
+
+export interface GifAnalysis {
+  width: number;
+  height: number;
+  frameCount: number;
+  durationMs: number;
+  delaysMs: number[];
+  timing: FrameTimingStats;
+  paletteEstimate: number;
+  hasTransparency: boolean;
+  interlaced: boolean;
+  disposalModes: number[];
+}
+
+export interface GifOptimizationOptions {
+  targetFps: number;
+  minDelayMs: number;
+  repeat: number;
+  quality: number;
+  sampleStride: number;
+}
+
+export interface GifOptimizationResult {
+  analysisBefore: GifAnalysis;
+  analysisAfter: GifAnalysis;
+  removedDuplicateFrames: number;
+  outputPath: string;
+}
+
+const DEFAULT_OPTIONS: GifOptimizationOptions = {
+  targetFps: 30,
+  minDelayMs: 20,
+  repeat: 0,
+  quality: 10,
+  sampleStride: 4,
+};
+
+export async function optimizeGif(
+  input: string | Buffer,
+  outputPath: string,
+  customOptions: Partial<GifOptimizationOptions> = {},
+): Promise<GifOptimizationResult> {
+  const options = { ...DEFAULT_OPTIONS, ...customOptions } satisfies GifOptimizationOptions;
+  const buffer = await loadGifBuffer(input);
+  const gif = parseGifBuffer(buffer);
+  const frames = decompressFrames(gif, true);
+  const width = gif.lsd.width;
+  const height = gif.lsd.height;
+  const desiredDelayMs = Math.max(options.minDelayMs, Math.round(1000 / options.targetFps));
+
+  const analysisBefore = await analyzeGif(buffer, options.sampleStride);
+  const { sanitized, removed } = sanitizeFrames(frames, width, height);
+
+  const canvas = createCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+  const encoder = new GIFEncoder(width, height);
+  const completion = configureEncoder(encoder, options);
+
+  for (const frame of sanitized) {
+    encoder.setDelay(desiredDelayMs);
+    const imageData = new ImageData(frame, width, height);
+    ctx.putImageData(imageData, 0, 0);
+    encoder.addFrame(ctx);
+  }
+
+  encoder.finish();
+  const gifBuffer = await completion;
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, gifBuffer);
+
+  const analysisAfter = await analyzeGif(await fs.readFile(outputPath), options.sampleStride);
+
+  return {
+    analysisBefore,
+    analysisAfter,
+    removedDuplicateFrames: removed,
+    outputPath: path.resolve(outputPath),
+  };
+}
+
+export async function analyzeGif(input: string | Buffer, sampleStride = DEFAULT_OPTIONS.sampleStride): Promise<GifAnalysis> {
+  const buffer = await loadGifBuffer(input);
+  const gif = parseGifBuffer(buffer);
+  const frames = decompressFrames(gif, true);
+  const delaysMs = frames.map((frame) => getDelayMs(frame.delay));
+  const durationMs = delaysMs.reduce((total, delay) => total + delay, 0);
+  const paletteEstimate = estimatePaletteSize(frames, sampleStride);
+  const hasTransparency = frames.some((frame) => frameHasTransparency(frame, sampleStride));
+  const interlaced = frames.some((frame) => frame.interlaced === true);
+  const disposalModes = Array.from(new Set(frames.map((frame) => frame.disposalType ?? 0))).sort(
+    (a, b) => a - b,
+  );
+
+  return {
+    width: gif.lsd.width,
+    height: gif.lsd.height,
+    frameCount: frames.length,
+    durationMs: roundTo(durationMs, 3),
+    delaysMs: delaysMs.map((delay) => roundTo(delay, 3)),
+    timing: calculateFrameTimingStats(delaysMs),
+    paletteEstimate,
+    hasTransparency,
+    interlaced,
+    disposalModes,
+  };
+}
+
+export function sanitizeFrames(frames: ParsedFrame[], width: number, height: number): {
+  sanitized: Uint8ClampedArray[];
+  removed: number;
+} {
+  const expanded = expandToFullFrames(frames, width, height);
+  const sanitized: Uint8ClampedArray[] = [];
+  let removed = 0;
+  let previousHash: string | null = null;
+
+  for (const frame of expanded) {
+    const hash = hashFrame(frame.data);
+    if (previousHash && previousHash === hash) {
+      removed++;
+      continue;
+    }
+
+    sanitized.push(frame.data);
+    previousHash = hash;
+  }
+
+  if (sanitized.length === 0 && expanded.length > 0) {
+    sanitized.push(expanded[0].data);
+  }
+
+  return { sanitized, removed };
+}
+
+async function loadGifBuffer(input: string | Buffer): Promise<Buffer> {
+  if (typeof input === 'string') {
+    return fs.readFile(input);
+  }
+
+  if (Buffer.isBuffer(input)) {
+    return input;
+  }
+
+  throw new TypeError('GIF input must be a file path or Buffer');
+}
+
+function parseGifBuffer(buffer: Buffer): ReturnType<typeof parseGIF> {
+  const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+  return parseGIF(arrayBuffer);
+}
+
+function configureEncoder(encoder: GIFEncoder, options: GifOptimizationOptions): Promise<Buffer> {
+  encoder.start();
+  encoder.setRepeat(options.repeat);
+  encoder.setQuality(options.quality);
+
+  const stream = encoder.createReadStream();
+  const chunks: Buffer[] = [];
+
+  return new Promise<Buffer>((resolve, reject) => {
+    stream.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    stream.once('end', () => resolve(Buffer.concat(chunks)));
+    stream.once('error', reject);
+  });
+}
+
+function getDelayMs(delayHundredths: number | undefined): number {
+  if (delayHundredths === undefined || delayHundredths === 0) {
+    return 100;
+  }
+
+  return delayHundredths * HUNDREDTHS_TO_MS;
+}
+
+function expandToFullFrames(frames: ParsedFrame[], width: number, height: number): GifFrame[] {
+  const fullSize = width * height * 4;
+  const background = new Uint8ClampedArray(fullSize);
+  let previous = new Uint8ClampedArray(background);
+
+  return frames.map((frame) => {
+    const beforeDrawing = new Uint8ClampedArray(previous);
+    const working = new Uint8ClampedArray(previous);
+    const { dims, patch } = frame;
+
+    if (patch) {
+      compositePatch(working, patch, dims, width);
+    }
+
+    const result = new Uint8ClampedArray(working);
+    const disposalType = frame.disposalType ?? 0;
+
+    switch (disposalType) {
+      case 2: {
+        const cleared = new Uint8ClampedArray(working);
+        clearPatch(cleared, dims, width);
+        previous = cleared;
+        break;
+      }
+      case 3: {
+        previous = beforeDrawing;
+        break;
+      }
+      default: {
+        previous = working;
+        break;
+      }
+    }
+
+    return {
+      data: result,
+      delayMs: getDelayMs(frame.delay),
+      disposalType,
+    } satisfies GifFrame;
+  });
+}
+
+function compositePatch(
+  destination: Uint8ClampedArray,
+  patch: Uint8ClampedArray,
+  dims: ParsedFrame['dims'],
+  width: number,
+): void {
+  const { top, left, width: patchWidth, height: patchHeight } = dims;
+
+  for (let y = 0; y < patchHeight; y += 1) {
+    for (let x = 0; x < patchWidth; x += 1) {
+      const patchIndex = (y * patchWidth + x) * 4;
+      const alpha = patch[patchIndex + 3];
+      if (alpha === 0) {
+        continue;
+      }
+
+      const destX = left + x;
+      const destY = top + y;
+      const destIndex = (destY * width + destX) * 4;
+      destination[destIndex] = patch[patchIndex];
+      destination[destIndex + 1] = patch[patchIndex + 1];
+      destination[destIndex + 2] = patch[patchIndex + 2];
+      destination[destIndex + 3] = alpha;
+    }
+  }
+}
+
+function clearPatch(destination: Uint8ClampedArray, dims: ParsedFrame['dims'], width: number): void {
+  const { top, left, width: patchWidth, height: patchHeight } = dims;
+
+  for (let y = 0; y < patchHeight; y += 1) {
+    for (let x = 0; x < patchWidth; x += 1) {
+      const destX = left + x;
+      const destY = top + y;
+      const destIndex = (destY * width + destX) * 4;
+      destination[destIndex] = 0;
+      destination[destIndex + 1] = 0;
+      destination[destIndex + 2] = 0;
+      destination[destIndex + 3] = 0;
+    }
+  }
+}
+
+function hashFrame(data: Uint8ClampedArray): string {
+  return createHash('sha1').update(data).digest('hex');
+}
+
+function estimatePaletteSize(frames: ParsedFrame[], stride: number): number {
+  const colors = new Set<string>();
+
+  for (const frame of frames) {
+    const patch = frame.patch;
+    if (!patch) {
+      continue;
+    }
+
+    for (let index = 0; index < patch.length; index += 4 * stride) {
+      const r = patch[index];
+      const g = patch[index + 1];
+      const b = patch[index + 2];
+      const a = patch[index + 3];
+      colors.add(`${r}-${g}-${b}-${a}`);
+    }
+  }
+
+  return colors.size;
+}
+
+function frameHasTransparency(frame: ParsedFrame, stride: number): boolean {
+  const patch = frame.patch;
+  if (!patch) {
+    return false;
+  }
+
+  for (let index = 3; index < patch.length; index += 4 * stride) {
+    if (patch[index] < 255) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/shared/media/rounding.ts
+++ b/src/shared/media/rounding.ts
@@ -1,0 +1,4 @@
+export function roundTo(value: number, precision: number): number {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}

--- a/src/shared/media/videoToolkit.ts
+++ b/src/shared/media/videoToolkit.ts
@@ -1,0 +1,176 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export type VideoContainer = 'mp4' | 'webm' | 'apng';
+
+export interface VideoExportRequest {
+  input: string | Buffer;
+  outputPath: string;
+  container: VideoContainer;
+  fps?: number;
+  bitrateKbps?: number;
+  keyframeInterval?: number;
+}
+
+export class FfmpegNotFoundError extends Error {
+  public constructor() {
+    super('ffmpeg binary not found. Install ffmpeg or set FFMPEG_PATH.');
+    this.name = 'FfmpegNotFoundError';
+  }
+}
+
+export async function exportVideo(request: VideoExportRequest): Promise<string> {
+  const workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'video-export-'));
+  const inputPath = await prepareInput(workDir, request.input);
+  const tempOutput = path.join(workDir, getOutputName(request.container));
+  const outputPath = path.resolve(request.outputPath);
+
+  try {
+    const args = buildArgs(request, inputPath, tempOutput);
+    await runFfmpeg(args);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.copyFile(tempOutput, outputPath);
+    return outputPath;
+  } catch (error) {
+    if (error instanceof FfmpegNotFoundError) {
+      throw error;
+    }
+
+    throw new Error(`Failed to export video: ${(error as Error).message}`);
+  } finally {
+    await fs.rm(workDir, { recursive: true, force: true });
+  }
+}
+
+function resolveFfmpegBinary(): string {
+  return process.env.FFMPEG_PATH ?? 'ffmpeg';
+}
+
+async function prepareInput(workDir: string, input: string | Buffer): Promise<string> {
+  if (typeof input === 'string') {
+    return path.resolve(input);
+  }
+
+  if (Buffer.isBuffer(input)) {
+    const target = path.join(workDir, 'input.gif');
+    await fs.writeFile(target, input);
+    return target;
+  }
+
+  throw new TypeError('Unsupported input type for video export');
+}
+
+function buildArgs(request: VideoExportRequest, inputPath: string, outputPath: string): string[] {
+  const fps = request.fps ?? 30;
+  const bitrate = request.bitrateKbps ?? 2200;
+  const keyint = request.keyframeInterval ?? fps * 2;
+  const filters = [`fps=${fps}`, 'scale=trunc(iw/2)*2:trunc(ih/2)*2:flags=lanczos'];
+
+  switch (request.container) {
+    case 'mp4':
+      return [
+        '-y',
+        '-i',
+        inputPath,
+        '-vf',
+        filters.join(','),
+        '-c:v',
+        'libx264',
+        '-profile:v',
+        'high',
+        '-pix_fmt',
+        'yuv420p',
+        '-b:v',
+        `${bitrate}k`,
+        '-maxrate',
+        `${bitrate}k`,
+        '-bufsize',
+        `${bitrate * 2}k`,
+        '-g',
+        `${keyint}`,
+        '-keyint_min',
+        `${keyint}`,
+        '-movflags',
+        '+faststart',
+        '-an',
+        outputPath,
+      ];
+    case 'webm':
+      return [
+        '-y',
+        '-i',
+        inputPath,
+        '-vf',
+        filters.join(','),
+        '-c:v',
+        'libvpx-vp9',
+        '-pix_fmt',
+        'yuva420p',
+        '-b:v',
+        `${bitrate}k`,
+        '-g',
+        `${keyint}`,
+        '-auto-alt-ref',
+        '0',
+        '-deadline',
+        'realtime',
+        '-cpu-used',
+        '5',
+        '-an',
+        outputPath,
+      ];
+    case 'apng':
+      return [
+        '-y',
+        '-i',
+        inputPath,
+        '-vf',
+        filters.join(','),
+        '-plays',
+        '0',
+        outputPath,
+      ];
+    default:
+      throw new TypeError(`Unsupported container: ${request.container}`);
+  }
+}
+
+async function runFfmpeg(args: string[]): Promise<void> {
+  const binary = resolveFfmpegBinary();
+
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(binary, args, { stdio: 'inherit' });
+
+    proc.on('error', (error) => {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        reject(new FfmpegNotFoundError());
+        return;
+      }
+
+      reject(error);
+    });
+
+    proc.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`ffmpeg exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function getOutputName(container: VideoContainer): string {
+  switch (container) {
+    case 'mp4':
+      return 'output.mp4';
+    case 'webm':
+      return 'output.webm';
+    case 'apng':
+      return 'output.apng';
+    default:
+      return 'output.bin';
+  }
+}

--- a/tests/unit/shared/media/gifToolkit.test.ts
+++ b/tests/unit/shared/media/gifToolkit.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it, beforeAll, afterAll, vi } from 'vitest';
+
+vi.doUnmock('gifuct-js');
+vi.doUnmock('@napi-rs/canvas');
+vi.doUnmock('gifencoder');
+
+const { analyzeGif, optimizeGif } = await import('@/shared/media/gifToolkit');
+const { calculateFrameTimingStats } = await import('@/shared/media/frameTiming');
+
+const SAMPLE_GIF = path.resolve('dedosgif.gif');
+
+describe('gifToolkit', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'gif-toolkit-test-'));
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('analyzes frame timing statistics consistently', async () => {
+    const buffer = await readFile(SAMPLE_GIF);
+    const analysis = await analyzeGif(buffer);
+
+    expect(analysis.frameCount).toBeGreaterThan(0);
+    expect(analysis.timing.fps).toBeGreaterThan(0);
+    expect(analysis.timing.stdDeviationMs).toBeGreaterThanOrEqual(0);
+    expect(analysis.delaysMs).toHaveLength(analysis.frameCount);
+  });
+
+  it('optimizes GIF to constant framerate with zero jitter', async () => {
+    const output = path.join(tempDir, 'optimized.gif');
+    const result = await optimizeGif(SAMPLE_GIF, output, { targetFps: 30 });
+
+    expect(result.analysisAfter.timing.fps).toBeGreaterThan(result.analysisBefore.timing.fps);
+    expect(result.analysisAfter.timing.stdDeviationMs).toBeLessThanOrEqual(
+      result.analysisBefore.timing.stdDeviationMs + 0.001,
+    );
+    expect(result.removedDuplicateFrames).toBeGreaterThanOrEqual(0);
+  });
+
+  it('computes jitter statistics for sample delays', () => {
+    const stats = calculateFrameTimingStats([30, 30, 30, 30]);
+    expect(stats.fps).toBeCloseTo(33.333, 3);
+    expect(stats.stdDeviationMs).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add GIF analysis and optimization utilities that normalize frame delays and compute palette metrics
- provide frame timing helpers, FFmpeg-based video export wrappers, and a CLI harness for generating comparative reports
- cover the media pipeline with jitter/FPS unit tests and expose the harness via `pnpm media:harness`

## Testing
- pnpm test:unit
- pnpm media:harness --input dedosgif.gif --outDir simulation/media-report-test --fps 30 --bitrate 2200 --keyint 60

------
https://chatgpt.com/codex/tasks/task_e_68e4bb0303888326a2ec0038351e8bb5